### PR TITLE
Add cookie prefix '-__Secure-'  to cookies to help prevent cookie smuggling (issue18608) 

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -960,7 +960,7 @@ class Config
      */
     public function issetCookie(string $cookieName): bool
     {
-        return isset($_COOKIE[$this->getCookieName($cookieName)]);
+    return ( $this->isHttps() ? '__Secure-' : '’ ) . $cookieName . ( $this->isHttps() ? '_https' : ‘’ );
     }
 
     /**


### PR DESCRIPTION
The PR will modify the 'GetCookieName' functtion by hard  coding the prefix ' __Secure-'  to each cookie name when 'isHttps()' is true, Apparently the prefix will be recognised  and enforced by most browsers (ignored by the older ones).

### Description

Please describe your pull request.
The raison d'aitre for this PR is contained in my issue # 18608.
That description referred to the file 'libraries/libraries/classes/config.php'.  I have been guided to the path 'phpmyadmin/src/Config.php' for the PR. Thank you WilliamDes.

This PR will replace the line 953, part of the GetCookieName function  :
**return $cookieName . ( $this->isHttps ? '_https' : '' );**

with the amended line:
**return ( $this->isHttps() ? '__Secure-' : '’ ) . $cookieName . ( $this->isHttps() ? '_https' : ‘’ );**

Descriptive commit message:
The PR will modify the 'GetCookieName' functtion by hard  coding the prefix ' __Secure-'  to each cookie name when 'isHttps()' is true, Apparently the prefix will be recognised  and enforced by most browsers (ignored by the older ones).

(A further enhancement might be by a check of the path and substituting '__Host-' if the path is '/'. This is not part of the PR.)

As per guidance I have directed this PR to QA_5_2




Signed-off-by: martin762  <martin762green@btinternet>